### PR TITLE
feat(signup): created signup page

### DIFF
--- a/front/src/context/AuthContext.tsx
+++ b/front/src/context/AuthContext.tsx
@@ -7,7 +7,6 @@ type SignInData = {
   password: string;
 };
 
-
 interface Props {
   children: React.ReactNode;
 }
@@ -84,7 +83,7 @@ export const AuthProvider: React.FC<Props> = ({ children }) => {
         icon: "success",
         title: `Bem Vindo!`,
       })
-      navigate('/encarregado')
+      navigate('/temp')
     } catch (err: any) {
       Notification.fire({
         icon: "error",
@@ -93,28 +92,11 @@ export const AuthProvider: React.FC<Props> = ({ children }) => {
     }
   }
 
-  // async function signUp({ email, password, name, phone }: SignUpData) {
-  //   setLoadingAuth(true)
-  //   try {
-  //     const response = await api.post("/customer", {
-  //       email: email,
-  //       password: password,
-  //       name: name,
-  //       phone: phone
-  //     });
-  //     setLoadingAuth(false)
-  //     setError('')
-  //     navigation.navigate('SignIn')
-  //   } catch (err: any) {
-  //     setLoadingAuth(false)
-  //     setError(err.response.data.message)
-  //   }
-  // }
 
   function logout() {
     try {
       localStorage.clear()
-      navigate('/login')
+      navigate('/')
     } catch (e: any) {
       setError(e.response.data.message)
     }
@@ -126,7 +108,6 @@ export const AuthProvider: React.FC<Props> = ({ children }) => {
     </AuthContext.Provider>
   );
 };
-
 export { AuthContext }
 
 export const useAuth = () => {

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -2,11 +2,19 @@ import { SetStateAction, useEffect, useState } from "react";
 import { api } from "../services/API";
 import {} from "react-hook-form";
 import { useForm } from "react-hook-form";
-import { useAuth } from './context/AuthContext';
+import { useAuth } from "./context/AuthContext";
 interface Costumer {
   id: number;
   name: string;
   contact: string;
+}
+
+interface User {
+  id: number;
+  uuid: string;
+  name: string;
+  login: string;
+  email: string;
 }
 interface FormValues {
   name: string;
@@ -15,9 +23,11 @@ interface FormValues {
 
 export default function Home() {
   const [costumers, setCostumers] = useState<Costumer[]>([]);
+  const [user, setUser] = useState<User[]>([]);
   const [value, setValue] = useState(0);
   const { register, handleSubmit } = useForm<FormValues>();
   const { logout } = useAuth();
+  const userJson = JSON.parse(localStorage.getItem("@App:user") || "{}");
 
   function handleLogout() {
     logout();
@@ -33,9 +43,13 @@ export default function Home() {
   };
 
   useEffect(() => {
-    api.get(`costumer`).then((res: { data: SetStateAction<Costumer[]>; }) => {
+    api.get(`costumer`).then((res: any) => {
       // const costumer = res.data;
       setCostumers(res.data);
+    });
+    api.get(`users/`).then((res: any) => {
+      const user = res.data;
+      setUser(user);
     });
   }, [value]);
   return (
@@ -53,12 +67,22 @@ export default function Home() {
       <form onSubmit={handleSubmit(onSubmit)}>
         <input type="text" {...register("name")} />
         <input type="text" {...register("contact")} />
-        <button>botao</button>
+        <button></button>
       </form>
-
-      <button 
-      onClick={handleLogout}
-      className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full">
+      {user.map((u) => {
+        return (
+          <div key={u.id}>
+            <input type="text" placeholder={u.name} />
+            <input type="text" placeholder={u.login} />
+            <input type="text" placeholder={u.email} />
+            <input type="text" placeholder={u.uuid} />
+          </div>
+        );
+      })}
+      <button
+        onClick={handleLogout}
+        className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full"
+      >
         Sair
       </button>
     </div>

--- a/front/src/pages/signup.tsx
+++ b/front/src/pages/signup.tsx
@@ -1,6 +1,45 @@
 import { LockClosedIcon } from "@heroicons/react/20/solid";
+import { useForm } from "react-hook-form";
+import { api } from "../../services/API";
+import { useState } from "react";
+import { Notification } from "../utils/Notification";
+import { useNavigate } from 'react-router-dom';
 
-export function  SignUp(){
+interface User {
+  name: string;
+  login: string;
+  email: string;
+  password: string;
+}
+interface IFormUser {
+  name: string;
+  login: string;
+  email: string;
+  password: string;
+}
+
+export function SignUp() {
+  const [user, setUser] = useState<User[]>([]);
+  const { register, handleSubmit } = useForm<IFormUser>();
+  const navigate = useNavigate();
+  const onSubmit = (data: IFormUser) => {
+    api
+      .post(`/auth/signup`, data)
+      .then(() => {
+        Notification.fire({
+          icon: "success",
+          title: `Conta criada com sucesso!\nBem vindo!`,
+        });
+        navigate('/temp')
+      })
+      .catch((err : any) => {
+        Notification.fire({
+          icon: "error",
+          title: `Erro ao criar conta`,
+          text: err
+        })
+      }) ;
+  };
   return (
     <div className="flex min-h-full items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
       <div className="w-full max-w-md space-y-8">
@@ -16,14 +55,14 @@ export function  SignUp(){
           <p className="mt-2 text-center text-sm text-gray-600">
             Ou{" "}
             <a
-              href="/login"
+              href="/"
               className="font-medium text-indigo-600 hover:text-indigo-500"
             >
               entre em sua conta
             </a>
           </p>
         </div>
-        <form action="$" className="mt-8 space-y-6">
+        <form onSubmit={handleSubmit(onSubmit)} action="$" className="mt-8 space-y-6">
           <input type="hidden" name="remember" value="true" />
           <div className="-space-y-px rounded-md shadow-sm">
             <div>
@@ -31,11 +70,23 @@ export function  SignUp(){
                 Nome
               </label>
               <input
-                name="name"
-                type="email"
+                type="text"
                 required
                 placeholder="Escreva aqui seu nome"
                 className="relative block w-full appearance-none rounded-none rounded-t-md border border-gray-300 px-3 py-2 text-gray-900 placeholder-gray-500 focus:z-10 focus:border-indigo-500 focus: outline-none focus:ring-indigo-500 sm:text-sm"
+                {...register("name")}
+              />
+            </div>
+            <div>
+              <label htmlFor="login" className="sr-only">
+                Login
+              </label>
+              <input
+              {...register("login")}
+                type="text"
+                required
+                placeholder="Login"
+                className="relative block w-full appearance-none rounded-none border border-gray-300 px-3 py-2 text-gray-900 placeholder-gray-500 focus:z-10 focus:border-indigo-500 focus: outline-none focus:ring-indigo-500 sm:text-sm"
               />
             </div>
             <div>
@@ -43,7 +94,7 @@ export function  SignUp(){
                 Email
               </label>
               <input
-                name="email"
+                {...register("email")}
                 autoComplete="email"
                 type="email"
                 required
@@ -52,21 +103,9 @@ export function  SignUp(){
               />
             </div>
             <div>
-              <label htmlFor="login" className="sr-only">
-                Login
-              </label>
-              <input
-                name="login"
-                type="text"
-                required
-                placeholder="Login"
-                className="relative block w-full appearance-none rounded-none border border-gray-300 px-3 py-2 text-gray-900 placeholder-gray-500 focus:z-10 focus:border-indigo-500 focus: outline-none focus:ring-indigo-500 sm:text-sm"
-              />
-            </div>
-            <div>
               <label htmlFor="password" className="sr-only"></label>
               <input
-                name="password"
+                {...register("password")}
                 type="password"
                 autoComplete="current-password"
                 required

--- a/front/src/routes/index.tsx
+++ b/front/src/routes/index.tsx
@@ -1,13 +1,14 @@
-import { Routes, Route } from 'react-router-dom'
-import { Login } from '../pages/login'
-import { SignUp } from '../pages/signup'
-import Home from './../index'
+import { Routes, Route } from "react-router-dom";
+import { Login } from "../pages/login";
+import { SignUp } from "../pages/signup";
+import Home from "./../index";
+import { CreateCostumer } from "../pages/modules/costumer/CreateCostumer";
 
 const Router: React.FC = () => (
   <Routes>
-    <Route path='/login' element={ <Login /> } />
-    <Route path='/temp' element={ <Home /> } />
-    <Route path='/signup' element={ <SignUp /> } />
+    <Route path="/" element={<Login />} />
+    <Route path="/temp" element={<Home />} />
+    <Route path="/signup" element={<SignUp />} />
   </Routes>
-)
-export default Router
+);
+export default Router;

--- a/front/src/routes/protectedRoute.tsx
+++ b/front/src/routes/protectedRoute.tsx
@@ -1,15 +1,18 @@
 import { useContext } from "react";
 import { AuthContext } from "../context/AuthContext";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useEffect } from "react";
 
 export const ProtectedRoute = ({ children }: { children: JSX.Element }) => {
   const auth = useContext(AuthContext);
   const navigate = useNavigate();
+  const location = useLocation();
   const storagedToken = localStorage.getItem("@App:token");
   useEffect(() => {
-    if (!storagedToken) {
-      navigate("/login");
+    if (!storagedToken && location.pathname !== '/signup') {
+      navigate("/")
+    } else if (!storagedToken) {
+      navigate('/signup')
     } else {
       navigate("/temp");
     }


### PR DESCRIPTION
- Created signup page:
  - now users can create account on `/signup` route
  - reload to `/temp` route when successful sigunp
- Changed logic of protected routes:
  - now users can only access `/signup` and `/` routes without having token on his local storage
- Updated tests file